### PR TITLE
Upgrade wagtail 1.3.x --> 1.4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.9,<1.10
-wagtail==1.3.1
+wagtail==1.4.2
 psycopg2==2.6.1
 wagtail-modeltranslation==0.4.4
 django-debug-toolbar==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=1.9,<1.10
 wagtail==1.4.2
 psycopg2==2.6.1
-wagtail-modeltranslation==0.4.4
+-e git+https://github.com/infoportugal/wagtail-modeltranslation.git@release/v0.5#egg=wagtail-modeltranslation
 django-debug-toolbar==1.4
 gunicorn==19.4.5
 dj-database-url==0.4.0

--- a/rtei/settings/base.py
+++ b/rtei/settings/base.py
@@ -45,7 +45,6 @@ INSTALLED_APPS = [
     'wagtail.wagtailcore',
 
     'modelcluster',
-    'compressor',
     'taggit',
     'storages',
 
@@ -142,8 +141,7 @@ LOCALE_PATHS = (
 
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder'
 ]
 
 STATICFILES_DIRS = [
@@ -157,8 +155,6 @@ STATIC_URL = '/static/'
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
-
-COMPRESS_ENABLED = False
 
 # Wagtail settings
 


### PR DESCRIPTION
To make use of new Wagtail features, such as image/document collections, and custom document models [1], we will need to upgrade to Wagtail 1.4.x.

wagtail-modeltranslation on pypi (0.4.4) isn't currently compatible with wagtail 1.4.x. But, it does have a `release/v0.5` branch, that is compatible [2].

This PR upgrades Wagtail to 1.4.2, and wagtail-modeltranslation to the release/v0.5 branch. It also removes django-compressor which is no longer required in wagtail.

[1] http://docs.wagtail.io/en/v1.4.2/releases/1.4.html
[2] https://github.com/infoportugal/wagtail-modeltranslation/issues/71
